### PR TITLE
feat: support for twilight.go

### DIFF
--- a/lib/deploy.js
+++ b/lib/deploy.js
@@ -18,8 +18,6 @@ module.exports = config => {
   return async (job, filePath) => {
     const mediaHost = dyn('media')
 
-    const fileId = job.media.id
-
     const child = logger.child({
       jobId: job.media.id
     })
@@ -49,12 +47,20 @@ module.exports = config => {
       child.debug('form', opts)
       try {
         const res = await request({
-          url: `${mediaHost}/v1/media/${fileId}`,
+          url: `${mediaHost}/v1/media`,
           formData: {
             file: {
               value: fileStream,
               options: opts
             }
+          },
+          headers: {
+            'X-Media-ID': job.media.id,
+            'X-Media-Type': job.media.type,
+            'X-Media-Name': job.media.name,
+
+            // Until we have support for quality
+            'X-Media-Quality': '1080p'
           },
           method: 'PUT',
           simple: false,

--- a/lib/download.js
+++ b/lib/download.js
@@ -9,13 +9,11 @@
 const path = require('path')
 const fs = require('fs-extra')
 const _ = require('lodash')
-const request = require('request-promise-native')
 const logger = require('pino')({
   name: path.basename(__filename)
 })
 
 const minio = require('triton-core/minio')
-const dyn = require('triton-core/dynamics')
 const proto = require('triton-core/proto')
 
 // main function
@@ -83,27 +81,6 @@ module.exports = async config => {
         child.error(`Failed to download from id '${fileId}' file '${o.name}'`)
         throw err
       }
-    }
-
-    // inform twilight of the new media
-    const body = {
-      name: job.media.name,
-      id: fileId,
-      files: originalLength,
-      type: job.media.type === 0 ? 'movie' : 'tv'
-    }
-
-    child.info('creating media:', job.media.name, body)
-    try {
-      await request({
-        method: 'POST',
-        url: `${dyn('media')}/v1/media`,
-        body,
-        json: true
-      })
-    } catch (err) {
-      child.error('Failed to connect to Twilight', err.message)
-      throw err
     }
 
     i = pos


### PR DESCRIPTION
**What this PR does**: Moves from standard js `twilight` to the, newer, now maintained version `twlight.go`.

This is part of the epic https://github.com/tritonmedia/triton/issues/8